### PR TITLE
Changing frequency bands default to avoid including alpha band if user provides a value

### DIFF
--- a/coffeine/power_features.py
+++ b/coffeine/power_features.py
@@ -120,9 +120,8 @@ def compute_features(
         'psds', 'covs', 'cross_frequency_covs', 'cross_frequency_corrs',
         'cospectral_covs')
 
-    frequency_bands_ = {'alpha': (8.0, 12.0)}
-    if frequency_bands is not None:
-        frequency_bands_.update(frequency_bands)
+    frequency_bands_ = {'alpha': (8.0, 12.0)} \
+        if frequency_bands is None else frequency_bands
     computed_features = {}
 
     if isinstance(inst, BaseRaw):

--- a/coffeine/tests/test_power_features.py
+++ b/coffeine/tests/test_power_features.py
@@ -10,6 +10,7 @@ data_dir = os.path.join(data_path, 'MEG', 'sample')
 raw_fname = os.path.join(data_dir, 'sample_audvis_raw.fif')
 
 frequency_bands = {'alpha': (8.0, 15.0), 'beta': (15.0, 30.0)}
+frequency_bands2 = {'theta': (4.0, 8.0), 'beta': (15.0, 30.0)}
 
 
 def test_compute_features_raw():
@@ -78,3 +79,19 @@ def test_compute_features_epochs():
             (n_fb * n_channels, n_fb * n_channels))
     assert (computed_features['cospectral_covs'].shape[1:] ==
             (n_channels, n_channels))
+
+
+@pytest.mark.parametrize('frequency_bands',
+                         [None, frequency_bands, frequency_bands2])
+def test_compute_features_covs_freq_band_defaults(frequency_bands):
+    raw = mne.io.read_raw_fif(raw_fname, verbose=False)
+    raw = raw.copy().crop(0, 200).pick(
+        [0, 1, 330, 331, 332]  # take some MEG and EEG
+    )
+    raw.info.normalize_proj()
+    computed_features, _ = compute_features(
+        raw, features=['covs'], frequency_bands=frequency_bands)
+
+    n_bands = computed_features['covs'].shape[0]
+    assert n_bands == 1 if frequency_bands is None \
+        else n_bands == len(frequency_bands)


### PR DESCRIPTION
This addresses #26. I left the default in, but just made sure that the alpha band would not be included if the user provides a value.