### PR TITLE
Use 'riemann' metric as default vectorization instead of wasserstein that is not available in pyriemann

### DIFF
--- a/coffeine/covariance_transformers.py
+++ b/coffeine/covariance_transformers.py
@@ -23,7 +23,7 @@ def _check_data(X):
 
 
 class Riemann(BaseEstimator, TransformerMixin):
-    def __init__(self, metric='wasserstein', return_data_frame=True):
+    def __init__(self, metric='riemann', return_data_frame=True):
         self.metric = metric
         self.return_data_frame = return_data_frame
 

--- a/coffeine/tests/test_pipelines.py
+++ b/coffeine/tests/test_pipelines.py
@@ -54,7 +54,7 @@ def test_pipelines(toy_data):
     regressor = make_filter_bank_classifier(
         names=frequency_bands.keys(),
         method='riemann',
-        vectorization_params=dict(metric='wasserstein'),
+        vectorization_params=dict(metric='riemann'),
         categorical_interaction="drug")
     y_bin = np.sign(y - np.mean(y))
     regressor.fit(X_df, y_bin)


### PR DESCRIPTION
For some reason, the metric 'wasserstein' is used as default in the Riemann class and then pass to the tangent_space function of pyriemann. But the wasserstein metric is not available in this function. This PR replaces 'wasserstein' default by 'riemann'.

See: https://github.com/pyRiemann/pyRiemann/blob/master/pyriemann/utils/tangentspace.py#L323-L326