### PR TITLE
Fix compatibility with pyriemann >= 0.7 (CospCovariances → CoSpectra)

### DIFF
--- a/coffeine/power_features.py
+++ b/coffeine/power_features.py
@@ -2,7 +2,12 @@ from typing import Union
 import numpy as np
 import pandas as pd
 from scipy.stats import trim_mean
-from pyriemann.estimation import CospCovariances
+try:
+    from pyriemann.estimation import CospCovariances
+except ImportError:
+    # CospCovariances was renamed to CoSpectra in pyriemann 0.6
+    # and removed in pyriemann 0.7 (PR #327)
+    from pyriemann.estimation import CoSpectra as CospCovariances
 import mne
 from mne.io import BaseRaw
 from mne.epochs import BaseEpochs


### PR DESCRIPTION
## Summary
- `CospCovariances` was renamed to `CoSpectra` in pyriemann 0.6 and removed in 0.7 (pyRiemann/pyRiemann#288, pyRiemann/pyRiemann#327)
- Since coffeine specifies `pyriemann>=0.2.7` with no upper bound, `pip install coffeine` with a fresh environment pulls pyriemann 0.10 and fails immediately with `ImportError: cannot import name 'CospCovariances'`
- Adds a try/except fallback to import `CoSpectra` when `CospCovariances` is unavailable, maintaining backwards compatibility

## Test plan
- [x] Verified with pyriemann 0.5 (old path: direct import works)
- [x] Verified with pyriemann 0.10 (new path: CoSpectra fallback works)
- [x] Full `coffeine.compute_features()` pipeline tested on CTF MEG data (274 channels, 59 epochs, 7 frequency bands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)